### PR TITLE
Allow custom CURL option in configuration

### DIFF
--- a/DependencyInjection/AcceleratorCacheExtension.php
+++ b/DependencyInjection/AcceleratorCacheExtension.php
@@ -19,5 +19,11 @@ class AcceleratorCacheExtension extends Extension
         $container->setParameter('accelerator_cache.host', $config['host'] ? trim($config['host'], '/') : false);
         $container->setParameter('accelerator_cache.web_dir', $config['web_dir']);
         $container->setParameter('accelerator_cache.mode', $config['mode']);
+
+        $curlOpts = array();
+        foreach ($config['curl_opts'] as $name => $value) {
+            $curlOpts[constant($name)] = $value;
+        }
+        $container->setParameter('accelerator_cache.curl_opts', $curlOpts);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,6 +26,19 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('host')->defaultFalse()->end()
                 ->scalarNode('web_dir')->isRequired()->end()
                 ->scalarNode('mode')->defaultValue('fopen')->end()
+                ->arrayNode('curl_opts')
+                    ->validate()
+                        ->always(function ($opts) {
+                            foreach (array_keys($opts) as $const)
+                                if (! defined($const) || substr($const, 0, 8) !== 'CURLOPT_')
+                                    throw new \InvalidArgumentException(sprintf("%s is not a valid CURLOPT option. (http://php.net/manual/en/function.curl-setopt.php)", json_encode($const)));
+                            return $opts;
+                        })
+                    ->end()
+                    ->defaultValue(array())
+                    ->useAttributeAsKey('name', false)
+                    ->prototype('scalar')->end()
+                ->end()
             ->end()
         ->end();
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Installation
     accelerator_cache:
         ...
         mode: curl
+    #   additional options can be passed to the command
+    #   curl_opts:
+    #       CURLOPT_*: custom_value
+
     ```
 
 Usage


### PR DESCRIPTION
I've added a configuration entry to pass custom curl options to the clear command.

My use case is for setting a custom certification authority, but there are countless other scenario, since there is no way to set global curl settings (AFAIK).
