### PR TITLE
Remove redundant dependencies

### DIFF
--- a/Command/AcceleratorCacheClearCommand.php
+++ b/Command/AcceleratorCacheClearCommand.php
@@ -3,13 +3,26 @@
 namespace SmartCore\Bundle\AcceleratorCacheBundle\Command;
 
 use SmartCore\Bundle\AcceleratorCacheBundle\AcceleratorCacheClearer;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use SmartCore\Bundle\AcceleratorCacheBundle\CacheClearerService;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class AcceleratorCacheClearCommand extends ContainerAwareCommand
+class AcceleratorCacheClearCommand extends Command
 {
+    /**
+     * @var CacheClearerService
+     */
+    private $cacheClearer;
+
+    public function __construct(CacheClearerService $cacheClearer)
+    {
+        parent::__construct(null);
+
+        $this->cacheClearer = $cacheClearer;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -38,8 +51,7 @@ class AcceleratorCacheClearCommand extends ContainerAwareCommand
             $type = 'cli';
             $result = AcceleratorCacheClearer::clearCache($clearUser, $clearOpcode);
         } else {
-            $result = $this->getContainer()->get('accelerator_cache.clearer')
-                ->clearCache($clearUser, $clearOpcode, $input->getOption('auth'));
+            $result = $this->cacheClearer->clearCache($clearUser, $clearOpcode, $input->getOption('auth'));
         }
 
         if (!$result['success']) {

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -3,10 +3,18 @@
 namespace SmartCore\Bundle\AcceleratorCacheBundle\Composer;
 
 use Composer\Script\Event;
-use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as SymfonyScriptHandler;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
 
-class ScriptHandler extends SymfonyScriptHandler
+/**
+ * @see \Sensio\Bundle\DistributionBundle\Composer\ScriptHandler
+ */
+class ScriptHandler
 {
+    private static $options = array(
+        'symfony-bin-dir' => 'app',
+    );
+
     /**
      * Clears the APC/Wincache/Opcache cache.
      *
@@ -14,17 +22,8 @@ class ScriptHandler extends SymfonyScriptHandler
      */
     public static function clearCache(Event $event)
     {
-        $options = parent::getOptions($event);
-        //$consoleDir = parent::getConsoleDir($event, 'clear the PHP Accelerator cache');
-        if (isset($options['symfony-bin-dir'])) {
-            $binDir = $options['symfony-bin-dir'];
-        } else {
-            $binDir = $options['symfony-app-dir'];
-        }
-
-        if (null === $binDir) {
-            return;
-        }
+        $options = self::getOptions($event);
+        $binDir = $options['symfony-bin-dir'];
 
         $opcode = '';
         if (array_key_exists('accelerator-cache-opcode', $options)) {
@@ -51,5 +50,90 @@ class ScriptHandler extends SymfonyScriptHandler
         } catch (\RuntimeException $e) {
             $event->getIO()->write('<error>'.$e->getMessage().'</error>');
         }
+    }
+
+    /**
+     * @param Event $event
+     * @return array
+     */
+    private static function getOptions(Event $event)
+    {
+        $options = array_merge(static::$options, $event->getComposer()->getPackage()->getExtra());
+
+        $options['process-timeout'] = $event->getComposer()->getConfig()->get('process-timeout');
+
+        return $options;
+    }
+
+    /**
+     * @param Event $event
+     * @param $consoleDir
+     * @param $cmd
+     * @param int $timeout
+     */
+    private static function executeCommand(Event $event, $consoleDir, $cmd, $timeout = 300)
+    {
+        $php = escapeshellarg(static::getPhp(false));
+        $phpArgs = implode(' ', array_map('escapeshellarg', static::getPhpArguments()));
+        $console = escapeshellarg($consoleDir.'/console');
+        if ($event->getIO()->isDecorated()) {
+            $console .= ' --ansi';
+        }
+
+        $process = new Process($php.($phpArgs ? ' '.$phpArgs : '').' '.$console.' '.$cmd, null, null, null, $timeout);
+        $process->run(function ($type, $buffer) use ($event) { $event->getIO()->write($buffer, false); });
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf("An error occurred when executing the \"%s\" command:\n\n%s\n\n%s", escapeshellarg($cmd), self::removeDecoration($process->getOutput()), self::removeDecoration($process->getErrorOutput())));
+        }
+    }
+
+    /**
+     * @param bool $includeArgs
+     * @return mixed
+     */
+    private static function getPhp($includeArgs = true)
+    {
+        $phpFinder = new PhpExecutableFinder();
+        if (!$phpPath = $phpFinder->find($includeArgs)) {
+            throw new \RuntimeException('The php executable could not be found, add it to your PATH environment variable and try again');
+        }
+
+        return $phpPath;
+    }
+
+    /**
+     * @return array
+     */
+    private static function getPhpArguments()
+    {
+        $ini = null;
+        $arguments = array();
+
+        $phpFinder = new PhpExecutableFinder();
+        if (method_exists($phpFinder, 'findArguments')) {
+            $arguments = $phpFinder->findArguments();
+        }
+
+        if ($env = getenv('COMPOSER_ORIGINAL_INIS')) {
+            $paths = explode(PATH_SEPARATOR, $env);
+            $ini = array_shift($paths);
+        } else {
+            $ini = php_ini_loaded_file();
+        }
+
+        if ($ini) {
+            $arguments[] = '--php-ini='.$ini;
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @param $string
+     * @return mixed
+     */
+    private static function removeDecoration($string)
+    {
+        return preg_replace("/\033\[[^m]*m/", '', $string);
     }
 }

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -12,5 +12,10 @@
             <argument>%accelerator_cache.mode%</argument>
             <argument>%accelerator_cache.curl_opts%</argument>
         </service>
+
+        <service id="accelerator_cache.command" class="SmartCore\Bundle\AcceleratorCacheBundle\Command\AcceleratorCacheClearCommand">
+            <argument type="service" id="accelerator_cache.clearer" />
+            <tag name="console.command" />
+        </service>
     </services>
 </container>

--- a/Tests/AcceleratorCacheClearerTest.php
+++ b/Tests/AcceleratorCacheClearerTest.php
@@ -7,7 +7,7 @@ use SmartCore\Bundle\AcceleratorCacheBundle\AcceleratorCacheClearer;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class AcceleratorCacheClearerTest extends \PHPUnit_Framework_TestCase
+class AcceleratorCacheClearerTest extends \PHPUnit\Framework\TestCase
 {
     public function testClearCache()
     {

--- a/Tests/CacheClearerServiceTest.php
+++ b/Tests/CacheClearerServiceTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class CacheClearerServiceTest extends \PHPUnit_Framework_TestCase
+class CacheClearerServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "symfony/framework-bundle": ">=2.1",
-        "sensio/distribution-bundle": ">=2.1"
+        "symfony/console": ">=2.1"
     },
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "symfony/console": ">=2.1",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.3"
+        "phpunit/phpunit": "~6.3",
+        "matthiasnoback/symfony-dependency-injection-test": "~2.1"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Remove `sensio/distribution-bundle` to use with Symfony Flex. It is possible to use `AcceleratorCacheBundle` but got redundant dependencies: `composer/ca-bundle` and `sensiolabs/security-checker`

Also update `AcceleratorCacheClearCommand` to be compatible with https://github.com/symfony/symfony/pull/23857
